### PR TITLE
Update CI workflow, GH Actions, and dev dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '7.2', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,6 @@ on:
       - main
       - v*.*
 
-env:
-  php-extensions: mbstring, intl
-  php-extensions-key: v1
-  php-tools: "composer:v2"
-
 jobs:
   phpstan:
     name: PHPStan
@@ -20,27 +15,16 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '7.2', '8.1', '8.2', '8.3' ]
+        php-version: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Setup PHP with pecl extension
+      - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-
-      - name: Get composer cache directory
-        id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
         run: composer install --prefer-dist
@@ -54,35 +38,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '7.2', '8.0', '8.1', '8.2', '8.3' ]
+        php-version: [ '7.2', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
 
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Setup PHP with pecl extension
+      - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: ${{ env.php-extensions }}
-          tools: ${{ env.php-tools }}
+          tools: composer:v2
           coverage: pcov
 
-      - name: Get composer cache directory
-        id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
       - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress --no-suggest
+        run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Tests
         run: ./vendor/bin/tester ./tests/cases

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,6 +1,3 @@
-includes:
-	- phar://%rootDir%/phpstan.phar/conf/bleedingEdge.neon
-
 parameters:
 	level: max
 	paths:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"issues": "https://github.com/nextras/multi-query-parser/issues"
 	},
 	"require": {
-		"php": "~7.2 || ~8.0"
+		"php": "~8.0"
 	},
 	"require-dev": {
 		"nette/tester": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
 	},
 	"require-dev": {
 		"nette/tester": "~2.0",
-		"phpstan/phpstan": "1.12.7",
+		"phpstan/phpstan": "2.1.17",
 		"phpstan/extension-installer": "1.4.3",
-		"phpstan/phpstan-strict-rules": "1.6.1"
+		"phpstan/phpstan-strict-rules": "2.0.4"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v2 → v4, remove deprecated `actions/cache` v2
- Extend PHP matrix: PHPStan 8.1–8.5, Tests 7.2–8.5
- Upgrade PHPStan 1.x → 2.x, phpstan-strict-rules 1.x → 2.x
- Remove `bleedingEdge.neon` include (merged into default in PHPStan 2)
- Simplify workflow by dropping dependency caching
- Remove deprecated `--no-suggest` flag and `::set-output` syntax

## Test plan
- [ ] All PHPStan jobs pass (PHP 8.1–8.5)
- [ ] All test jobs pass (PHP 7.2–8.5)