### PR TITLE
Fix parsing of superfluous semicolons

### DIFF
--- a/src/MySqlMultiQueryParser.php
+++ b/src/MySqlMultiQueryParser.php
@@ -52,7 +52,7 @@ class MySqlMultiQueryParser extends BaseMultiQueryParser
 							|   /\\*                                                  (?: [^*]++   | \\*(?!/)        )*+ \\*/
 							|   --[^\\n]*+(?:\\n|\\z)
 							|   (?!$delimiterPattern) .
-						)++
+						)*+
 					)
 					(?: $delimiterPattern | \\z )
 				)

--- a/src/PostgreSqlMultiQueryParser.php
+++ b/src/PostgreSqlMultiQueryParser.php
@@ -43,7 +43,7 @@ class PostgreSqlMultiQueryParser extends BaseMultiQueryParser
 							|   (\\$(?:[a-zA-Z_\\x80-\\xFF][\\w\\x80-\\xFF]*+)?\\$) (?: [^$]++   | (?!\\g{-1})\\$ )*+ \\g{-1}
 							|   -- [^\\n]*+
 							|   (?!;) .
-						)++
+						)*+
 					)
 					(?: ; | \\z )
 				)

--- a/src/SqlServerMultiQueryParser.php
+++ b/src/SqlServerMultiQueryParser.php
@@ -57,7 +57,7 @@ class SqlServerMultiQueryParser extends BaseMultiQueryParser
 							|   BEGIN (?: \s*END\s*| ' . substr($simpleQuery, 1, -2) . ')*
 							|   -- [^\\n]*+
 							|   (?!;) .
-						)++
+						)*+
 					)
 					(?: ; | \\z )
 				)

--- a/tests/cases/PostgreSqlMultiQueryParserTest.phpt
+++ b/tests/cases/PostgreSqlMultiQueryParserTest.phpt
@@ -15,6 +15,52 @@ require_once __DIR__ . '/../bootstrap.php';
 
 class PostgreSqlMultiQueryParserTest extends TestCase
 {
+	/**
+	 * @dataProvider provideSuperfluousSemicolonsData
+	 * @param list<string> $expectedQueries
+	 */
+	public function testSuperfluousSemicolons(string $content, array $expectedQueries): void
+	{
+		$parser = new PostgreSqlMultiQueryParser();
+		$queries = iterator_to_array($parser->parseString($content));
+		Assert::same($expectedQueries, $queries);
+	}
+
+
+	/**
+	 * @return list<array{string, list<string>}>
+	 */
+	protected function provideSuperfluousSemicolonsData(): array
+	{
+		return [
+			[
+				'SELECT 1 AS semicolon_madness;;;',
+				['SELECT 1 AS semicolon_madness'],
+			],
+			[
+				';;',
+				[],
+			],
+			[
+				';;;',
+				[],
+			],
+			[
+				';SELECT 1;',
+				['SELECT 1'],
+			],
+			[
+				'SELECT 1;;SELECT 2;',
+				['SELECT 1', 'SELECT 2'],
+			],
+			[
+				'SELECT 1; ; SELECT 2;',
+				['SELECT 1', 'SELECT 2'],
+			],
+		];
+	}
+
+
 	public function testFile(): void
 	{
 		$parser = new PostgreSqlMultiQueryParser();

--- a/tests/cases/SqlServerMultiQueryParserTest.phpt
+++ b/tests/cases/SqlServerMultiQueryParserTest.phpt
@@ -15,6 +15,52 @@ require_once __DIR__ . '/../bootstrap.php';
 
 class SqlServerMultiQueryParserTest extends TestCase
 {
+	/**
+	 * @dataProvider provideSuperfluousSemicolonsData
+	 * @param list<string> $expectedQueries
+	 */
+	public function testSuperfluousSemicolons(string $content, array $expectedQueries): void
+	{
+		$parser = new SqlServerMultiQueryParser();
+		$queries = iterator_to_array($parser->parseString($content));
+		Assert::same($expectedQueries, $queries);
+	}
+
+
+	/**
+	 * @return list<array{string, list<string>}>
+	 */
+	protected function provideSuperfluousSemicolonsData(): array
+	{
+		return [
+			[
+				'SELECT 1 AS semicolon_madness;;;',
+				['SELECT 1 AS semicolon_madness'],
+			],
+			[
+				';;',
+				[],
+			],
+			[
+				';;;',
+				[],
+			],
+			[
+				';SELECT 1;',
+				['SELECT 1'],
+			],
+			[
+				'SELECT 1;;SELECT 2;',
+				['SELECT 1', 'SELECT 2'],
+			],
+			[
+				'SELECT 1; ; SELECT 2;',
+				['SELECT 1', 'SELECT 2'],
+			],
+		];
+	}
+
+
 	public function testFile(): void
 	{
 		$parser = new SqlServerMultiQueryParser();


### PR DESCRIPTION
## Summary
- All three parsers (MySQL, PostgreSQL, SQL Server) threw `RuntimeException` when encountering superfluous semicolons (e.g. `SELECT 1;;;`)
- Changed the query capture group quantifier from `++` (one or more) to `*+` (zero or more) so bare semicolons are consumed as empty queries, which are already filtered by the existing `$match['query'] !== ''` check
- Added `testSuperfluousSemicolons` data-provider tests to all three parser test files covering: trailing extra semicolons, leading semicolons, only semicolons, and semicolons between queries

## Test plan
- [x] All 45 tests pass (including 6 new superfluous semicolons test cases per parser)
- [x] Existing delimiter, file parsing, and randomized chunking tests unaffected