### PR TITLE
Add missing @throws annotations to IMultiQueryParser

### DIFF
--- a/src/IMultiQueryParser.php
+++ b/src/IMultiQueryParser.php
@@ -3,6 +3,7 @@
 namespace Nextras\MultiQueryParser;
 
 use Iterator;
+use Nextras\MultiQueryParser\Exception\RuntimeException;
 
 
 interface IMultiQueryParser
@@ -13,6 +14,7 @@ interface IMultiQueryParser
 	/**
 	 * @param  positive-int $chunkSize
 	 * @return Iterator<string>
+	 * @throws RuntimeException
 	 */
 	public function parseFile(string $path, int $chunkSize = self::DEFAULT_CHUNK_SIZE): Iterator;
 
@@ -21,12 +23,14 @@ interface IMultiQueryParser
 	 * @param  resource     $fileStream
 	 * @param  positive-int $chunkSize
 	 * @return Iterator<string>
+	 * @throws RuntimeException
 	 */
 	public function parseFileStream($fileStream, int $chunkSize = self::DEFAULT_CHUNK_SIZE): Iterator;
 
 
 	/**
 	 * @return Iterator<string>
+	 * @throws RuntimeException
 	 */
 	public function parseString(string $s): Iterator;
 
@@ -34,6 +38,7 @@ interface IMultiQueryParser
 	/**
 	 * @param  Iterator<string> $stream
 	 * @return Iterator<string>
+	 * @throws RuntimeException
 	 */
 	public function parseStringStream(Iterator $stream): Iterator;
 }


### PR DESCRIPTION
## Summary
- Added `@throws RuntimeException` annotations to all four methods in the `IMultiQueryParser` interface
- The implementations throw `Nextras\MultiQueryParser\Exception\RuntimeException` in several places (file open failures, stream read errors, regex failures) but the interface did not document this

## Test plan
- [x] Verify the annotations reference the correct exception class
- [ ] Run PHPStan to confirm no new static analysis issues