### PR TITLE
Fix PatternIterator skipping stream data after empty chunk

### DIFF
--- a/src/PatternIterator.php
+++ b/src/PatternIterator.php
@@ -77,12 +77,12 @@ class PatternIterator implements IteratorAggregate
 					break;
 				}
 
-				if (strlen($matches[0]) === 0) {
-					break 2;
-				}
-
 				if (strlen($matches[0]) + $offset === strlen($s) && $this->stream->valid()) {
 					break;
+				}
+
+				if (strlen($matches[0]) === 0) {
+					break 2;
 				}
 
 				yield $matches;

--- a/tests/cases/MySqlMultiQueryParserTest.phpt
+++ b/tests/cases/MySqlMultiQueryParserTest.phpt
@@ -68,6 +68,26 @@ class MySqlMultiQueryParserTest extends TestCase
 	}
 
 
+	public function testFileWithAllTwoChunkCombinations(): void
+	{
+		$content = file_get_contents(__DIR__ . '/data/mysql.sql');
+
+		if ($content === false) {
+			throw new LogicException('Failed to read file content');
+		}
+
+		$parser = new MySqlMultiQueryParser();
+		$expected = iterator_to_array($parser->parseString($content));
+		$len = strlen($content);
+
+		for ($i = 0; $i <= $len; $i++) {
+			$chunks = [substr($content, 0, $i), substr($content, $i)];
+			$queries = iterator_to_array($parser->parseStringStream(new \ArrayIterator($chunks)));
+			Assert::same($expected, $queries, "Failed with chunk boundary at offset $i");
+		}
+	}
+
+
 	/**
 	 * @return list<string>
 	 */

--- a/tests/cases/PatternIteratorTest.phpt
+++ b/tests/cases/PatternIteratorTest.phpt
@@ -78,6 +78,60 @@ class PatternIteratorTest extends TestCase
 	}
 
 
+	public function testEmptyChunkBeforeData(): void
+	{
+		$iter = new PatternIterator($this->stream('', 'ab;cd;'), '~[^;]+;~A');
+		$results = $this->collect($iter);
+		Assert::count(2, $results);
+		Assert::same('ab;', $results[0][0]);
+		Assert::same('cd;', $results[1][0]);
+	}
+
+
+	public function testEmptyChunkBeforeDataWithZeroLengthPattern(): void
+	{
+		$pattern = '~\s*(?:(?<query>[^;]+);|\z)~As';
+		$iter = new PatternIterator($this->stream('', 'a;b;'), $pattern);
+		$results = $this->collect($iter);
+		Assert::count(2, $results);
+		Assert::same('a', $results[0]['query']);
+		Assert::same('b', $results[1]['query']);
+	}
+
+
+	public function testMultipleEmptyChunksBeforeData(): void
+	{
+		$pattern = '~\s*(?:(?<query>[^;]+);|\z)~As';
+		$iter = new PatternIterator($this->stream('', '', '', 'a;b;'), $pattern);
+		$results = $this->collect($iter);
+		Assert::count(2, $results);
+		Assert::same('a', $results[0]['query']);
+		Assert::same('b', $results[1]['query']);
+	}
+
+
+	public function testEmptyChunksBetweenData(): void
+	{
+		$pattern = '~\s*(?:(?<query>[^;]+);|\z)~As';
+		$iter = new PatternIterator($this->stream('a;', '', '', 'b;'), $pattern);
+		$results = $this->collect($iter);
+		Assert::count(2, $results);
+		Assert::same('a', $results[0]['query']);
+		Assert::same('b', $results[1]['query']);
+	}
+
+
+	public function testEmptyChunkAfterData(): void
+	{
+		$pattern = '~\s*(?:(?<query>[^;]+);|\z)~As';
+		$iter = new PatternIterator($this->stream('a;b;', ''), $pattern);
+		$results = $this->collect($iter);
+		Assert::count(2, $results);
+		Assert::same('a', $results[0]['query']);
+		Assert::same('b', $results[1]['query']);
+	}
+
+
 	// =====================================================================
 	// Single chunk – basic matching
 	// =====================================================================

--- a/tests/cases/PostgreSqlMultiQueryParserTest.phpt
+++ b/tests/cases/PostgreSqlMultiQueryParserTest.phpt
@@ -250,6 +250,26 @@ END;
 	}
 
 
+	public function testFileWithAllTwoChunkCombinations(): void
+	{
+		$content = file_get_contents(__DIR__ . '/data/postgres.sql');
+
+		if ($content === false) {
+			throw new LogicException('Failed to read file content');
+		}
+
+		$parser = new PostgreSqlMultiQueryParser();
+		$expected = iterator_to_array($parser->parseString($content));
+		$len = strlen($content);
+
+		for ($i = 0; $i <= $len; $i++) {
+			$chunks = [substr($content, 0, $i), substr($content, $i)];
+			$queries = iterator_to_array($parser->parseStringStream(new \ArrayIterator($chunks)));
+			Assert::same($expected, $queries, "Failed with chunk boundary at offset $i");
+		}
+	}
+
+
 	/**
 	 * @return list<string>
 	 */

--- a/tests/cases/SqlServerMultiQueryParserTest.phpt
+++ b/tests/cases/SqlServerMultiQueryParserTest.phpt
@@ -279,6 +279,26 @@ END", $queries[67]);
 	}
 
 
+	public function testFileWithAllTwoChunkCombinations(): void
+	{
+		$content = file_get_contents(__DIR__ . '/data/sqlserver.sql');
+
+		if ($content === false) {
+			throw new LogicException('Failed to read file content');
+		}
+
+		$parser = new SqlServerMultiQueryParser();
+		$expected = iterator_to_array($parser->parseString($content));
+		$len = strlen($content);
+
+		for ($i = 0; $i <= $len; $i++) {
+			$chunks = [substr($content, 0, $i), substr($content, $i)];
+			$queries = iterator_to_array($parser->parseStringStream(new \ArrayIterator($chunks)));
+			Assert::same($expected, $queries, "Failed with chunk boundary at offset $i");
+		}
+	}
+
+
 	/**
 	 * @return list<string>
 	 */


### PR DESCRIPTION
## Summary
- Fixed a bug in `PatternIterator` where an empty chunk followed by data would cause the iterator to terminate early, discarding all remaining chunks. The root cause was the zero-length match guard (`break 2`) firing before the boundary safety check — swapping these two checks ensures empty chunks simply trigger loading the next chunk when the stream has more data.
- Added exhaustive two-chunk-split tests (`testFileWithAllTwoChunkCombinations`) for all three parsers (MySQL, PostgreSQL, SQL Server) that split the SQL fixture file at every possible byte offset.
- Added empty-chunk tests to `PatternIteratorTest` covering empty chunks before, between, and after data with `\z`-containing patterns.

## Test plan
- [x] All 57 existing tests pass
- [x] New `testFileWithAllTwoChunkCombinations` tests pass for all three parsers
- [x] New `PatternIteratorTest` empty-chunk tests pass