### PR TITLE
Change empty-match exit from break 2 to break

### DIFF
--- a/src/PatternIterator.php
+++ b/src/PatternIterator.php
@@ -82,7 +82,7 @@ class PatternIterator implements IteratorAggregate
 				}
 
 				if (strlen($matches[0]) === 0) {
-					break 2;
+					break;
 				}
 
 				yield $matches;

--- a/tests/cases/PatternIteratorTest.phpt
+++ b/tests/cases/PatternIteratorTest.phpt
@@ -524,6 +524,20 @@ class PatternIteratorTest extends TestCase
 	}
 
 
+	public function testZeroLengthMatchMidBufferLoadsMoreData(): void
+	{
+		// Pattern matches exactly 3 chars, or empty. When only 1 char remains in the
+		// buffer but the stream has more data, the empty match mid-buffer must not abort;
+		// loading the next chunk makes the 3-char alternative succeed.
+		$iter = new PatternIterator($this->stream('abXY', 'Zmore'), '~.{3}|~A');
+		$results = $this->collect($iter);
+		Assert::count(3, $results);
+		Assert::same('abX', $results[0][0]);
+		Assert::same('YZm', $results[1][0]);
+		Assert::same('ore', $results[2][0]);
+	}
+
+
 	public function testZeroLengthMatchAcrossChunks(): void
 	{
 		$pattern = '~\s*(?:(?<query>[^;]+);|\z)~As';


### PR DESCRIPTION
## Summary
- Changes `break 2` to `break` on empty match in `PatternIterator::getIterator()` for simpler control flow that is easier to reason about.
- Adds a regression test (`testZeroLengthMatchMidBufferLoadsMoreData`) demonstrating a case where `break 2` would incorrectly abort: when an empty match occurs mid-buffer because a fixed-width alternative needs more characters than remain, loading the next chunk resolves it into a positive-length match.

## Context
With `break 2`, an empty match mid-buffer with the stream still active would immediately exit both loops and throw. With `break`, the iterator returns to the outer loop, loads the next chunk, and retries — which can turn the empty match into a successful one when more data is available.

Since the library's SQL tokenizer patterns never produce empty matches in practice, the `break 2` fail-fast offered no real benefit while being harder to reason about.

## Test plan
- [x] `vendor/bin/tester tests/` — all 65 tests pass