### PR TITLE
Update dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
 		"php": "~8.0"
 	},
 	"require-dev": {
-		"nette/tester": "~2.0",
-		"phpstan/phpstan": "2.1.17",
+		"nette/tester": "^2.6",
+		"phpstan/phpstan": "2.1.40",
 		"phpstan/extension-installer": "1.4.3",
-		"phpstan/phpstan-strict-rules": "2.0.4"
+		"phpstan/phpstan-strict-rules": "2.0.10"
 	},
 	"autoload": {
 		"psr-4": {
@@ -35,7 +35,7 @@
 	},
 	"scripts": {
 		"phpstan": "phpstan analyze",
-		"tests": "tester -C ./tests/cases"
+		"tests": "tester tests/cases"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
## Summary
- Bump `nette/tester` from `~2.0` to `^2.6`
- Bump `phpstan` from `2.1.17` to `2.1.40`
- Bump `phpstan-strict-rules` from `2.0.4` to `2.0.10`
- Simplify tester command (remove `-C` flag and `./` prefix)

## Test plan
- [ ] Verify `composer install` succeeds
- [ ] Run `composer tests` and confirm tests pass
- [ ] Run `composer phpstan` and confirm no new errors