### PR TITLE
Add CommentStrategy to optionally preserve leading comments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,12 +60,17 @@ foreach ($parser->parseFileStream($stream) as $query) {
 
 Available parsers: `MySqlMultiQueryParser`, `PostgreSqlMultiQueryParser`, `SqlServerMultiQueryParser`, `SqliteMultiQueryParser`.
 
-**Preserve leading comments:**
+**Keep leading comments:**
 
-By default, comments preceding a query are stripped. Pass `preserveLeadingComments: true` to any parser to keep them as a prefix of the yielded query instead -- useful when comments carry meaningful annotations:
+By default, comments are stripped and only query strings are yielded. To control what happens to
+comments, pass a `CommentStrategy` to the parser constructor. The bundled `KeepLeadingComments`
+strategy keeps the comments preceding a query as a prefix of that query -- useful when comments
+carry meaningful annotations, e.g. so they remain visible in observability tools:
 
 ```php
-$parser = new MySqlMultiQueryParser(preserveLeadingComments: true);
+use Nextras\MultiQueryParser\Strategy\KeepLeadingComments;
+
+$parser = new MySqlMultiQueryParser(new KeepLeadingComments());
 
 $sql = "-- create the users table\nCREATE TABLE users (id INT);";
 
@@ -75,6 +80,35 @@ foreach ($parser->parseString($sql) as $query) {
 ```
 
 All comment styles supported by the given dialect (`--`, `/* */`, and `#` for MySQL) that directly precede a query are preserved with their original formatting; only pure leading whitespace is stripped. A comment that sits between two queries is treated as preceding the following one. Comments not followed by any query (e.g. a trailing comment at the end of input) are dropped.
+
+**Custom comment handling:**
+
+Internally a parser tokenizes the input into a stream of `Query` and `Comment` fragments; the
+`CommentStrategy` collapses that stream into the final query strings. The default `DropComments`
+strategy discards every comment. To implement a different policy (for example, requiring a blank
+line between a comment and its query, or appending trailing comments), implement `CommentStrategy`
+yourself:
+
+```php
+use Iterator;
+use Nextras\MultiQueryParser\CommentStrategy;
+use Nextras\MultiQueryParser\Fragment\Query;
+
+final class MyCommentStrategy implements CommentStrategy
+{
+    public function apply(Iterator $fragments): Iterator
+    {
+        foreach ($fragments as $fragment) {
+            if ($fragment instanceof Query) {
+                yield $fragment->sql;
+            }
+            // decide what to do with Comment fragments
+        }
+    }
+}
+
+$parser = new MySqlMultiQueryParser(new MyCommentStrategy());
+```
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -81,35 +81,6 @@ foreach ($parser->parseString($sql) as $query) {
 
 All comment styles supported by the given dialect (`--`, `/* */`, and `#` for MySQL) that directly precede a query are preserved with their original formatting; only pure leading whitespace is stripped. A comment that sits between two queries is treated as preceding the following one. Comments not followed by any query (e.g. a trailing comment at the end of input) are dropped.
 
-**Custom comment handling:**
-
-Internally a parser tokenizes the input into a stream of `Query` and `Comment` fragments; the
-`CommentStrategy` collapses that stream into the final query strings. The default `DropComments`
-strategy discards every comment. To implement a different policy (for example, requiring a blank
-line between a comment and its query, or appending trailing comments), implement `CommentStrategy`
-yourself:
-
-```php
-use Iterator;
-use Nextras\MultiQueryParser\CommentStrategy;
-use Nextras\MultiQueryParser\Fragment\Query;
-
-final class MyCommentStrategy implements CommentStrategy
-{
-    public function apply(Iterator $fragments): Iterator
-    {
-        foreach ($fragments as $fragment) {
-            if ($fragment instanceof Query) {
-                yield $fragment->sql;
-            }
-            // decide what to do with Comment fragments
-        }
-    }
-}
-
-$parser = new MySqlMultiQueryParser(new MyCommentStrategy());
-```
-
 ### License
 
 MIT. See full [license](license.md).

--- a/readme.md
+++ b/readme.md
@@ -60,9 +60,9 @@ foreach ($parser->parseFileStream($stream) as $query) {
 
 Available parsers: `MySqlMultiQueryParser`, `PostgreSqlMultiQueryParser`, `SqlServerMultiQueryParser`, `SqliteMultiQueryParser`.
 
-**Preserve leading comments (MySQL):**
+**Preserve leading comments:**
 
-By default, comments preceding a query are stripped. Pass `preserveLeadingComments: true` to keep them as a prefix of the yielded query instead -- useful when comments carry meaningful annotations:
+By default, comments preceding a query are stripped. Pass `preserveLeadingComments: true` to any parser to keep them as a prefix of the yielded query instead -- useful when comments carry meaningful annotations:
 
 ```php
 $parser = new MySqlMultiQueryParser(preserveLeadingComments: true);
@@ -74,7 +74,7 @@ foreach ($parser->parseString($sql) as $query) {
 }
 ```
 
-All comment styles (`--`, `#`, `/* */`) that directly precede a query are preserved with their original formatting; only pure leading whitespace is stripped. A comment that sits between two queries is treated as preceding the following one. Comments not followed by any query (e.g. a trailing comment at the end of input) are dropped.
+All comment styles supported by the given dialect (`--`, `/* */`, and `#` for MySQL) that directly precede a query are preserved with their original formatting; only pure leading whitespace is stripped. A comment that sits between two queries is treated as preceding the following one. Comments not followed by any query (e.g. a trailing comment at the end of input) are dropped.
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -63,14 +63,14 @@ Available parsers: `MySqlMultiQueryParser`, `PostgreSqlMultiQueryParser`, `SqlSe
 **Keep leading comments:**
 
 By default, comments are stripped and only query strings are yielded. To control what happens to
-comments, pass a `CommentStrategy` to the parser constructor. The bundled `KeepLeadingComments`
+comments, pass a `CommentStrategy` to the parser constructor. The bundled `PrependLeadingComments`
 strategy keeps the comments preceding a query as a prefix of that query -- useful when comments
 carry meaningful annotations, e.g. so they remain visible in observability tools:
 
 ```php
-use Nextras\MultiQueryParser\Strategy\KeepLeadingComments;
+use Nextras\MultiQueryParser\Strategy\PrependLeadingComments;
 
-$parser = new MySqlMultiQueryParser(new KeepLeadingComments());
+$parser = new MySqlMultiQueryParser(new PrependLeadingComments());
 
 $sql = "-- create the users table\nCREATE TABLE users (id INT);";
 

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,22 @@ foreach ($parser->parseFileStream($stream) as $query) {
 
 Available parsers: `MySqlMultiQueryParser`, `PostgreSqlMultiQueryParser`, `SqlServerMultiQueryParser`, `SqliteMultiQueryParser`.
 
+**Preserve leading comments (MySQL):**
+
+By default, comments preceding a query are stripped. Pass `preserveLeadingComments: true` to keep them as a prefix of the yielded query instead -- useful when comments carry meaningful annotations:
+
+```php
+$parser = new MySqlMultiQueryParser(preserveLeadingComments: true);
+
+$sql = "-- create the users table\nCREATE TABLE users (id INT);";
+
+foreach ($parser->parseString($sql) as $query) {
+    echo $query; // "-- create the users table\nCREATE TABLE users (id INT)"
+}
+```
+
+All comment styles (`--`, `#`, `/* */`) that directly precede a query are preserved with their original formatting; only pure leading whitespace is stripped. A comment that sits between two queries is treated as preceding the following one. Comments not followed by any query (e.g. a trailing comment at the end of input) are dropped.
+
 ### License
 
 MIT. See full [license](license.md).

--- a/src/BaseMultiQueryParser.php
+++ b/src/BaseMultiQueryParser.php
@@ -5,6 +5,10 @@ namespace Nextras\MultiQueryParser;
 use ArrayIterator;
 use Iterator;
 use Nextras\MultiQueryParser\Exception\RuntimeException;
+use Nextras\MultiQueryParser\Fragment\Comment;
+use Nextras\MultiQueryParser\Fragment\Fragment;
+use Nextras\MultiQueryParser\Fragment\Query;
+use Nextras\MultiQueryParser\Strategy\DropComments;
 use function feof;
 use function fopen;
 use function fread;
@@ -12,9 +16,12 @@ use function fread;
 
 abstract class BaseMultiQueryParser implements IMultiQueryParser
 {
-	public function __construct(
-		private bool $preserveLeadingComments = false,
-	) {
+	private CommentStrategy $commentStrategy;
+
+
+	public function __construct(?CommentStrategy $commentStrategy = null)
+	{
+		$this->commentStrategy = $commentStrategy ?? new DropComments();
 	}
 
 
@@ -58,21 +65,31 @@ abstract class BaseMultiQueryParser implements IMultiQueryParser
 	 * @param  Iterator<string> $stream
 	 * @return Iterator<string>
 	 */
-	abstract public function parseStringStream(Iterator $stream): Iterator;
+	final public function parseStringStream(Iterator $stream): Iterator
+	{
+		return $this->commentStrategy->apply($this->parseStringStreamToFragments($stream));
+	}
 
 
 	/**
-	 * Builds the yielded query string, prepending captured leading comments when enabled.
-	 *
-	 * @param array<array-key, string> $match
+	 * @param  Iterator<string> $stream
+	 * @return Iterator<Fragment>
 	 */
-	protected function buildQuery(array $match): string
+	abstract protected function parseStringStreamToFragments(Iterator $stream): Iterator;
+
+
+	/**
+	 * @return Iterator<Fragment>
+	 */
+	protected function buildFragments(?string $leadingComments, ?string $query): Iterator
 	{
-		if (!$this->preserveLeadingComments) {
-			return $match['query'];
+		if ($leadingComments !== null && $leadingComments !== '') {
+			yield new Comment($leadingComments);
 		}
 
-		return ($match['leadingComments'] ?? '') . $match['query'];
+		if ($query !== null && $query !== '') {
+			yield new Query($query);
+		}
 	}
 
 

--- a/src/BaseMultiQueryParser.php
+++ b/src/BaseMultiQueryParser.php
@@ -65,7 +65,7 @@ abstract class BaseMultiQueryParser implements IMultiQueryParser
 	 * @param  Iterator<string> $stream
 	 * @return Iterator<string>
 	 */
-	final public function parseStringStream(Iterator $stream): Iterator
+	public function parseStringStream(Iterator $stream): Iterator
 	{
 		return $this->commentStrategy->apply($this->parseStringStreamToFragments($stream));
 	}

--- a/src/BaseMultiQueryParser.php
+++ b/src/BaseMultiQueryParser.php
@@ -13,6 +13,17 @@ use function fread;
 abstract class BaseMultiQueryParser implements IMultiQueryParser
 {
 	/**
+	 * @param bool $preserveLeadingComments When true, comments preceding a query are kept as a prefix of
+	 *                                       the yielded query string instead of being stripped. Only pure
+	 *                                       leading whitespace is stripped.
+	 */
+	public function __construct(
+		protected bool $preserveLeadingComments = false,
+	) {
+	}
+
+
+	/**
 	 * @param  positive-int $chunkSize
 	 * @return Iterator<string>
 	 */
@@ -53,6 +64,23 @@ abstract class BaseMultiQueryParser implements IMultiQueryParser
 	 * @return Iterator<string>
 	 */
 	abstract public function parseStringStream(Iterator $stream): Iterator;
+
+
+	/**
+	 * Builds the yielded query string, prepending captured leading comments when enabled.
+	 *
+	 * @param array<mixed> $match
+	 */
+	protected function buildQuery(array $match): string
+	{
+		$query = (string) $match['query'];
+
+		if (!$this->preserveLeadingComments) {
+			return $query;
+		}
+
+		return (string) ($match['leadingComments'] ?? '') . $query;
+	}
 
 
 	/**

--- a/src/BaseMultiQueryParser.php
+++ b/src/BaseMultiQueryParser.php
@@ -69,17 +69,15 @@ abstract class BaseMultiQueryParser implements IMultiQueryParser
 	/**
 	 * Builds the yielded query string, prepending captured leading comments when enabled.
 	 *
-	 * @param array<mixed> $match
+	 * @param array<array-key, string> $match
 	 */
 	protected function buildQuery(array $match): string
 	{
-		$query = (string) $match['query'];
-
 		if (!$this->preserveLeadingComments) {
-			return $query;
+			return $match['query'];
 		}
 
-		return (string) ($match['leadingComments'] ?? '') . $query;
+		return ($match['leadingComments'] ?? '') . $match['query'];
 	}
 
 

--- a/src/BaseMultiQueryParser.php
+++ b/src/BaseMultiQueryParser.php
@@ -18,7 +18,7 @@ abstract class BaseMultiQueryParser implements IMultiQueryParser
 	 *                                       leading whitespace is stripped.
 	 */
 	public function __construct(
-		protected bool $preserveLeadingComments = false,
+		private bool $preserveLeadingComments = false,
 	) {
 	}
 

--- a/src/BaseMultiQueryParser.php
+++ b/src/BaseMultiQueryParser.php
@@ -12,11 +12,6 @@ use function fread;
 
 abstract class BaseMultiQueryParser implements IMultiQueryParser
 {
-	/**
-	 * @param bool $preserveLeadingComments When true, comments preceding a query are kept as a prefix of
-	 *                                       the yielded query string instead of being stripped. Only pure
-	 *                                       leading whitespace is stripped.
-	 */
 	public function __construct(
 		private bool $preserveLeadingComments = false,
 	) {

--- a/src/CommentStrategy.php
+++ b/src/CommentStrategy.php
@@ -15,8 +15,8 @@ use Nextras\MultiQueryParser\Fragment\Fragment;
 interface CommentStrategy
 {
 	/**
-	 * @param  Iterator<int, Fragment> $fragments
-	 * @return Iterator<int, string>
+	 * @param  Iterator<Fragment> $fragments
+	 * @return Iterator<string>
 	 */
 	public function apply(Iterator $fragments): Iterator;
 }

--- a/src/CommentStrategy.php
+++ b/src/CommentStrategy.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\MultiQueryParser;
+
+use Iterator;
+use Nextras\MultiQueryParser\Fragment\Fragment;
+
+
+/**
+ * Decides what happens to the comments found in the parsed SQL stream.
+ *
+ * The parsers themselves only tokenize the input into a neutral {@see Fragment} stream of queries
+ * and comments; the strategy collapses that stream into the final stream of query strings.
+ */
+interface CommentStrategy
+{
+	/**
+	 * @param  Iterator<int, Fragment> $fragments
+	 * @return Iterator<int, string>
+	 */
+	public function apply(Iterator $fragments): Iterator;
+}

--- a/src/Fragment/Comment.php
+++ b/src/Fragment/Comment.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\MultiQueryParser\Fragment;
+
+
+/**
+ * A run of one or more comments (and the whitespace interleaved with them).
+ */
+final class Comment implements Fragment
+{
+	public function __construct(
+		public string $text,
+	) {
+	}
+}

--- a/src/Fragment/Fragment.php
+++ b/src/Fragment/Fragment.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\MultiQueryParser\Fragment;
+
+
+/**
+ * @phpstan-sealed Query|Comment
+ */
+interface Fragment
+{
+}

--- a/src/Fragment/Query.php
+++ b/src/Fragment/Query.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\MultiQueryParser\Fragment;
+
+
+/**
+ * A single SQL query (without its terminating delimiter).
+ */
+final class Query implements Fragment
+{
+	public function __construct(
+		public string $sql,
+	) {
+	}
+}

--- a/src/MySqlMultiQueryParser.php
+++ b/src/MySqlMultiQueryParser.php
@@ -8,17 +8,6 @@ use function preg_quote;
 
 class MySqlMultiQueryParser extends BaseMultiQueryParser
 {
-	/**
-	 * @param bool $preserveLeadingComments When true, comments (`--`, `#`, `/* *​/`) that precede a query
-	 *                                       are kept as a prefix of the yielded query string instead of
-	 *                                       being stripped. Only pure leading whitespace is stripped.
-	 */
-	public function __construct(
-		private bool $preserveLeadingComments = false,
-	) {
-	}
-
-
 	public function parseStringStream(Iterator $stream): Iterator
 	{
 		$patternIterator = new PatternIterator($stream, $this->getQueryPattern(';'));
@@ -28,8 +17,7 @@ class MySqlMultiQueryParser extends BaseMultiQueryParser
 				$patternIterator->setPattern($this->getQueryPattern($match['delimiter']));
 
 			} elseif (isset($match['query']) && $match['query'] !== '') {
-				$leadingComments = $this->preserveLeadingComments ? (string) $match['leadingComments'] : '';
-				yield $leadingComments . $match['query'];
+				yield $this->buildQuery($match);
 			}
 		}
 	}

--- a/src/MySqlMultiQueryParser.php
+++ b/src/MySqlMultiQueryParser.php
@@ -8,6 +8,17 @@ use function preg_quote;
 
 class MySqlMultiQueryParser extends BaseMultiQueryParser
 {
+	/**
+	 * @param bool $preserveLeadingComments When true, comments (`--`, `#`, `/* *​/`) that precede a query
+	 *                                       are kept as a prefix of the yielded query string instead of
+	 *                                       being stripped. Only pure leading whitespace is stripped.
+	 */
+	public function __construct(
+		private bool $preserveLeadingComments = false,
+	) {
+	}
+
+
 	public function parseStringStream(Iterator $stream): Iterator
 	{
 		$patternIterator = new PatternIterator($stream, $this->getQueryPattern(';'));
@@ -17,7 +28,8 @@ class MySqlMultiQueryParser extends BaseMultiQueryParser
 				$patternIterator->setPattern($this->getQueryPattern($match['delimiter']));
 
 			} elseif (isset($match['query']) && $match['query'] !== '') {
-				yield $match['query'];
+				$leadingComments = $this->preserveLeadingComments ? (string) $match['leadingComments'] : '';
+				yield $leadingComments . $match['query'];
 			}
 		}
 	}
@@ -30,12 +42,15 @@ class MySqlMultiQueryParser extends BaseMultiQueryParser
 
 		return /** @lang PhpRegExp */ "
 		~
-			(?:
-					\\s
-				|   /\\* (*PRUNE) (?: [^*]++ | \\*(?!/) )*+  \\*/
-				|   --[^\\n]*+(?:\\n|\\z)
-				|   \\#[^\\n]*+(?:\\n|\\z)
-			)*+
+			\\s*+
+			(?<leadingComments>
+				(?:
+						\\s
+					|   /\\* (*PRUNE) (?: [^*]++ | \\*(?!/) )*+  \\*/
+					|   --[^\\n]*+(?:\\n|\\z)
+					|   \\#[^\\n]*+(?:\\n|\\z)
+				)*+
+			)
 
 			(?:
 				(?i:

--- a/src/MySqlMultiQueryParser.php
+++ b/src/MySqlMultiQueryParser.php
@@ -8,16 +8,15 @@ use function preg_quote;
 
 class MySqlMultiQueryParser extends BaseMultiQueryParser
 {
-	public function parseStringStream(Iterator $stream): Iterator
+	protected function parseStringStreamToFragments(Iterator $stream): Iterator
 	{
 		$patternIterator = new PatternIterator($stream, $this->getQueryPattern(';'));
 
 		foreach ($patternIterator as $match) {
+			yield from $this->buildFragments($match['leadingComments'] ?? null, $match['query'] ?? null);
+
 			if (isset($match['delimiter']) && $match['delimiter'] !== '') {
 				$patternIterator->setPattern($this->getQueryPattern($match['delimiter']));
-
-			} elseif (isset($match['query']) && $match['query'] !== '') {
-				yield $this->buildQuery($match);
 			}
 		}
 	}

--- a/src/PatternIterator.php
+++ b/src/PatternIterator.php
@@ -30,7 +30,7 @@ use function substr;
  * the regex engine commits to the construct — if the closing delimiter is missing (because
  * it is in a later chunk), the overall match fails, causing the iterator to load more data.
  *
- * @implements IteratorAggregate<int, array<mixed>>
+ * @implements IteratorAggregate<int, array<array-key, string>>
  */
 class PatternIterator implements IteratorAggregate
 {

--- a/src/PostgreSqlMultiQueryParser.php
+++ b/src/PostgreSqlMultiQueryParser.php
@@ -7,14 +7,12 @@ use Iterator;
 
 class PostgreSqlMultiQueryParser extends BaseMultiQueryParser
 {
-	public function parseStringStream(Iterator $stream): Iterator
+	protected function parseStringStreamToFragments(Iterator $stream): Iterator
 	{
 		$patternIterator = new PatternIterator($stream, $this->getQueryPattern());
 
 		foreach ($patternIterator as $match) {
-			if (isset($match['query']) && $match['query'] !== '') {
-				yield $this->buildQuery($match);
-			}
+			yield from $this->buildFragments($match['leadingComments'] ?? null, $match['query'] ?? null);
 		}
 	}
 

--- a/src/PostgreSqlMultiQueryParser.php
+++ b/src/PostgreSqlMultiQueryParser.php
@@ -13,7 +13,7 @@ class PostgreSqlMultiQueryParser extends BaseMultiQueryParser
 
 		foreach ($patternIterator as $match) {
 			if (isset($match['query']) && $match['query'] !== '') {
-				yield $match['query'];
+				yield $this->buildQuery($match);
 			}
 		}
 	}
@@ -29,11 +29,14 @@ class PostgreSqlMultiQueryParser extends BaseMultiQueryParser
 				(?<nestedBc> /\\* (?: [^/*]++ | /(?!\\*) | \\*(?!/) | (?&nestedBc) )*+ \\*/ )
 			)
 
-			(?:
-					\\s
-				|   /\\* (*PRUNE) (?: [^/*]++ | /(?!\\*) | \\*(?!/) | (?&nestedBc) )*+ \\*/
-				|   -- [^\\n]*+
-			)*+
+			\\s*+
+			(?<leadingComments>
+				(?:
+						\\s
+					|   /\\* (*PRUNE) (?: [^/*]++ | /(?!\\*) | \\*(?!/) | (?&nestedBc) )*+ \\*/
+					|   -- [^\\n]*+
+				)*+
+			)
 
 			(?:
 				(?:

--- a/src/SqlServerMultiQueryParser.php
+++ b/src/SqlServerMultiQueryParser.php
@@ -7,14 +7,12 @@ use Iterator;
 
 class SqlServerMultiQueryParser extends BaseMultiQueryParser
 {
-	public function parseStringStream(Iterator $stream): Iterator
+	protected function parseStringStreamToFragments(Iterator $stream): Iterator
 	{
 		$patternIterator = new PatternIterator($stream, $this->getQueryPattern());
 
 		foreach ($patternIterator as $match) {
-			if (isset($match['query']) && $match['query'] !== '') {
-				yield $this->buildQuery($match);
-			}
+			yield from $this->buildFragments($match['leadingComments'] ?? null, $match['query'] ?? null);
 		}
 	}
 

--- a/src/SqlServerMultiQueryParser.php
+++ b/src/SqlServerMultiQueryParser.php
@@ -13,7 +13,7 @@ class SqlServerMultiQueryParser extends BaseMultiQueryParser
 
 		foreach ($patternIterator as $match) {
 			if (isset($match['query']) && $match['query'] !== '') {
-				yield $match['query'];
+				yield $this->buildQuery($match);
 			}
 		}
 	}
@@ -45,11 +45,14 @@ class SqlServerMultiQueryParser extends BaseMultiQueryParser
 				(?<nestedBc> /\\* (?: [^/*]++ | /(?!\\*) | \\*(?!/) | (?&nestedBc) )*+ \\*/ )
 			)
 
-			(?:
-					\\s
-				|   /\\* (*PRUNE) (?: [^/*]++ | /(?!\\*) | \\*(?!/) | (?&nestedBc) )*+ \\*/
-				|   -- [^\\n]*+
-			)*+
+			\\s*+
+			(?<leadingComments>
+				(?:
+						\\s
+					|   /\\* (*PRUNE) (?: [^/*]++ | /(?!\\*) | \\*(?!/) | (?&nestedBc) )*+ \\*/
+					|   -- [^\\n]*+
+				)*+
+			)
 
 			(?:
 				(?:

--- a/src/SqliteMultiQueryParser.php
+++ b/src/SqliteMultiQueryParser.php
@@ -13,7 +13,7 @@ class SqliteMultiQueryParser extends BaseMultiQueryParser
 
 		foreach ($patternIterator as $match) {
 			if (isset($match['query']) && $match['query'] !== '') {
-				yield $match['query'];
+				yield $this->buildQuery($match);
 			}
 		}
 	}
@@ -55,7 +55,8 @@ class SqliteMultiQueryParser extends BaseMultiQueryParser
 				)
 			)
 
-			(?&skip)
+			\s*+
+			(?<leadingComments> (?&skip) )
 
 			(?:
 				(?:

--- a/src/SqliteMultiQueryParser.php
+++ b/src/SqliteMultiQueryParser.php
@@ -7,14 +7,12 @@ use Iterator;
 
 class SqliteMultiQueryParser extends BaseMultiQueryParser
 {
-	public function parseStringStream(Iterator $stream): Iterator
+	protected function parseStringStreamToFragments(Iterator $stream): Iterator
 	{
 		$patternIterator = new PatternIterator($stream, $this->getQueryPattern());
 
 		foreach ($patternIterator as $match) {
-			if (isset($match['query']) && $match['query'] !== '') {
-				yield $this->buildQuery($match);
-			}
+			yield from $this->buildFragments($match['leadingComments'] ?? null, $match['query'] ?? null);
 		}
 	}
 

--- a/src/Strategy/DropComments.php
+++ b/src/Strategy/DropComments.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\MultiQueryParser\Strategy;
+
+use Iterator;
+use Nextras\MultiQueryParser\CommentStrategy;
+use Nextras\MultiQueryParser\Fragment\Query;
+
+
+final class DropComments implements CommentStrategy
+{
+	public function apply(Iterator $fragments): Iterator
+	{
+		foreach ($fragments as $fragment) {
+			if ($fragment instanceof Query) {
+				yield $fragment->sql;
+			}
+		}
+	}
+}

--- a/src/Strategy/KeepLeadingComments.php
+++ b/src/Strategy/KeepLeadingComments.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\MultiQueryParser\Strategy;
+
+use Iterator;
+use Nextras\MultiQueryParser\CommentStrategy;
+use Nextras\MultiQueryParser\Fragment\Comment;
+use Nextras\MultiQueryParser\Fragment\Query;
+
+
+/**
+ * Prepends the comments preceding a query to that query, keeping their original formatting.
+ *
+ * Comments not followed by any query (e.g. a trailing comment at the end of input) are dropped,
+ * since there is no query to attach them to.
+ */
+final class KeepLeadingComments implements CommentStrategy
+{
+	public function apply(Iterator $fragments): Iterator
+	{
+		$leadingComments = '';
+
+		foreach ($fragments as $fragment) {
+			if ($fragment instanceof Comment) {
+				$leadingComments .= $fragment->text;
+
+			} elseif ($fragment instanceof Query) {
+				yield $leadingComments . $fragment->sql;
+				$leadingComments = '';
+			}
+		}
+	}
+}

--- a/src/Strategy/PrependLeadingComments.php
+++ b/src/Strategy/PrependLeadingComments.php
@@ -14,7 +14,7 @@ use Nextras\MultiQueryParser\Fragment\Query;
  * Comments not followed by any query (e.g. a trailing comment at the end of input) are dropped,
  * since there is no query to attach them to.
  */
-final class KeepLeadingComments implements CommentStrategy
+final class PrependLeadingComments implements CommentStrategy
 {
 	public function apply(Iterator $fragments): Iterator
 	{

--- a/tests/cases/CommentStrategyTest.phpt
+++ b/tests/cases/CommentStrategyTest.phpt
@@ -1,0 +1,84 @@
+<?php declare(strict_types = 1);
+
+/**
+ * @testCase
+ */
+
+namespace Nextras\MultiQueryParser;
+
+use ArrayIterator;
+use Nextras\MultiQueryParser\Fragment\Comment;
+use Nextras\MultiQueryParser\Fragment\Fragment;
+use Nextras\MultiQueryParser\Fragment\Query;
+use Nextras\MultiQueryParser\Strategy\DropComments;
+use Nextras\MultiQueryParser\Strategy\KeepLeadingComments;
+use Tester\Assert;
+use Tester\TestCase;
+
+
+require_once __DIR__ . '/../bootstrap.php';
+
+
+class CommentStrategyTest extends TestCase
+{
+	public function testDropCommentsDropsComments(): void
+	{
+		$result = $this->apply(new DropComments(), [
+			new Comment('-- a'),
+			new Query('SELECT 1'),
+			new Comment('-- b'),
+			new Query('SELECT 2'),
+			new Comment('-- trailing'),
+		]);
+
+		Assert::same(['SELECT 1', 'SELECT 2'], $result);
+	}
+
+
+	public function testKeepLeadingCommentsPrependsComments(): void
+	{
+		$result = $this->apply(new KeepLeadingComments(), [
+			new Comment("-- a\n"),
+			new Query('SELECT 1'),
+			new Comment("-- b\n"),
+			new Query('SELECT 2'),
+		]);
+
+		Assert::same(["-- a\nSELECT 1", "-- b\nSELECT 2"], $result);
+	}
+
+
+	public function testKeepLeadingCommentsWithoutComments(): void
+	{
+		$result = $this->apply(new KeepLeadingComments(), [
+			new Query('SELECT 1'),
+			new Query('SELECT 2'),
+		]);
+
+		Assert::same(['SELECT 1', 'SELECT 2'], $result);
+	}
+
+
+	public function testKeepLeadingCommentsDropsTrailingComment(): void
+	{
+		$result = $this->apply(new KeepLeadingComments(), [
+			new Query('SELECT 1'),
+			new Comment('-- trailing'),
+		]);
+
+		Assert::same(['SELECT 1'], $result);
+	}
+
+
+	/**
+	 * @param  list<Fragment> $fragments
+	 * @return list<string>
+	 */
+	private function apply(CommentStrategy $strategy, array $fragments): array
+	{
+		return iterator_to_array($strategy->apply(new ArrayIterator($fragments)), false);
+	}
+}
+
+
+(new CommentStrategyTest())->run();

--- a/tests/cases/CommentStrategyTest.phpt
+++ b/tests/cases/CommentStrategyTest.phpt
@@ -11,7 +11,7 @@ use Nextras\MultiQueryParser\Fragment\Comment;
 use Nextras\MultiQueryParser\Fragment\Fragment;
 use Nextras\MultiQueryParser\Fragment\Query;
 use Nextras\MultiQueryParser\Strategy\DropComments;
-use Nextras\MultiQueryParser\Strategy\KeepLeadingComments;
+use Nextras\MultiQueryParser\Strategy\PrependLeadingComments;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -35,9 +35,9 @@ class CommentStrategyTest extends TestCase
 	}
 
 
-	public function testKeepLeadingCommentsPrependsComments(): void
+	public function testPrependLeadingComments(): void
 	{
-		$result = $this->apply(new KeepLeadingComments(), [
+		$result = $this->apply(new PrependLeadingComments(), [
 			new Comment("-- a\n"),
 			new Query('SELECT 1'),
 			new Comment("-- b\n"),
@@ -48,9 +48,9 @@ class CommentStrategyTest extends TestCase
 	}
 
 
-	public function testKeepLeadingCommentsWithoutComments(): void
+	public function testPrependLeadingCommentsWithoutComments(): void
 	{
-		$result = $this->apply(new KeepLeadingComments(), [
+		$result = $this->apply(new PrependLeadingComments(), [
 			new Query('SELECT 1'),
 			new Query('SELECT 2'),
 		]);
@@ -59,9 +59,9 @@ class CommentStrategyTest extends TestCase
 	}
 
 
-	public function testKeepLeadingCommentsDropsTrailingComment(): void
+	public function testPrependLeadingCommentsDropsTrailingComment(): void
 	{
-		$result = $this->apply(new KeepLeadingComments(), [
+		$result = $this->apply(new PrependLeadingComments(), [
 			new Query('SELECT 1'),
 			new Comment('-- trailing'),
 		]);

--- a/tests/cases/MySqlMultiQueryParserTest.phpt
+++ b/tests/cases/MySqlMultiQueryParserTest.phpt
@@ -6,6 +6,9 @@
 
 namespace Nextras\MultiQueryParser;
 
+use Nextras\MultiQueryParser\Fragment\Comment;
+use Nextras\MultiQueryParser\Fragment\Query;
+use Nextras\MultiQueryParser\Strategy\KeepLeadingComments;
 use Tester\Assert;
 
 
@@ -15,9 +18,9 @@ require_once __DIR__ . '/../inc/MultiQueryParserTestCase.php';
 
 class MySqlMultiQueryParserTest extends MultiQueryParserTestCase
 {
-	protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser
+	protected function createParser(?CommentStrategy $commentStrategy = null): IMultiQueryParser
 	{
-		return new MySqlMultiQueryParser($preserveLeadingComments);
+		return new MySqlMultiQueryParser($commentStrategy);
 	}
 
 
@@ -54,7 +57,7 @@ class MySqlMultiQueryParserTest extends MultiQueryParserTestCase
 	 */
 	public function testPreserveLeadingCommentsHash(string $content, array $expectedQueries): void
 	{
-		$parser = $this->createParser(preserveLeadingComments: true);
+		$parser = $this->createParser(new KeepLeadingComments());
 		$queries = iterator_to_array($parser->parseString($content));
 		Assert::same($expectedQueries, $queries);
 	}
@@ -84,6 +87,33 @@ class MySqlMultiQueryParserTest extends MultiQueryParserTestCase
 			// Hash-comment-only input yields nothing
 			["# only a comment", []],
 		];
+	}
+
+
+	/**
+	 * A comment preceding a DELIMITER directive must still be emitted as a Comment fragment, so
+	 * that a strategy can attach it to the following query instead of the parser dropping it.
+	 */
+	public function testCommentBeforeDelimiterIsEmittedAsFragment(): void
+	{
+		$content = "-- before delimiter\nDELIMITER //\nSELECT 1//";
+
+		$fragments = $this->collectFragments($content);
+		Assert::count(2, $fragments);
+
+		$comment = $fragments[0];
+		Assert::type(Comment::class, $comment);
+		assert($comment instanceof Comment);
+		Assert::same("-- before delimiter\n", $comment->text);
+
+		$query = $fragments[1];
+		Assert::type(Query::class, $query);
+		assert($query instanceof Query);
+		Assert::same('SELECT 1', $query->sql);
+
+		// under KeepLeadingComments the comment attaches to the following query
+		$queries = iterator_to_array($this->createParser(new KeepLeadingComments())->parseString($content));
+		Assert::same(["-- before delimiter\nSELECT 1"], $queries);
 	}
 
 

--- a/tests/cases/MySqlMultiQueryParserTest.phpt
+++ b/tests/cases/MySqlMultiQueryParserTest.phpt
@@ -15,9 +15,9 @@ require_once __DIR__ . '/../inc/MultiQueryParserTestCase.php';
 
 class MySqlMultiQueryParserTest extends MultiQueryParserTestCase
 {
-	protected function createParser(): IMultiQueryParser
+	protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser
 	{
-		return new MySqlMultiQueryParser();
+		return new MySqlMultiQueryParser($preserveLeadingComments);
 	}
 
 
@@ -46,109 +46,43 @@ class MySqlMultiQueryParserTest extends MultiQueryParserTestCase
 
 
 	/**
-	 * @dataProvider providePreserveLeadingCommentsData
+	 * MySQL-specific leading-comment cases: # hash comments. The generic line- and
+	 * block-comment cases are covered by the shared test in MultiQueryParserTestCase.
+	 *
+	 * @dataProvider providePreserveLeadingCommentsHashData
 	 * @param list<string> $expectedQueries
 	 */
-	public function testPreserveLeadingComments(string $content, array $expectedQueries): void
+	public function testPreserveLeadingCommentsHash(string $content, array $expectedQueries): void
 	{
-		$parser = new MySqlMultiQueryParser(preserveLeadingComments: true);
+		$parser = $this->createParser(preserveLeadingComments: true);
 		$queries = iterator_to_array($parser->parseString($content));
 		Assert::same($expectedQueries, $queries);
 	}
 
 
 	/**
-	 * The restructured leading-comment pattern must keep streaming chunk-safe.
-	 * Every two-chunk split of the input must reproduce the whole-string result.
-	 */
-	public function testPreserveLeadingCommentsChunkBoundary(): void
-	{
-		$parser = new MySqlMultiQueryParser(preserveLeadingComments: true);
-		$content = implode("\n", [
-			'-- header comment',
-			'-- second line',
-			'SELECT 1;',
-			'',
-			'# hash note',
-			'SELECT 2;',
-			'/* block ; with semi */',
-			'SELECT 3;',
-			'SELECT 4; -- trailing',
-			'-- leading before 5',
-			'SELECT 5;',
-		]);
-
-		$expected = iterator_to_array($parser->parseString($content));
-		$len = strlen($content);
-
-		for ($i = 0; $i <= $len; $i++) {
-			$chunks = [substr($content, 0, $i), substr($content, $i)];
-			$queries = iterator_to_array($parser->parseStringStream(new \ArrayIterator($chunks)));
-			Assert::same($expected, $queries, "Failed with chunk boundary at offset $i");
-		}
-	}
-
-
-	/**
 	 * @return list<array{string, list<string>}>
 	 */
-	protected function providePreserveLeadingCommentsData(): array
+	protected function providePreserveLeadingCommentsHashData(): array
 	{
 		return [
-			// Single -- comment kept as a prefix of the following query
-			[
-				"-- add users table\nCREATE TABLE users (id INT);",
-				["-- add users table\nCREATE TABLE users (id INT)"],
-			],
-			// Multiple consecutive -- comment lines
-			[
-				"-- line 1\n-- line 2\nSELECT 1;",
-				["-- line 1\n-- line 2\nSELECT 1"],
-			],
-			// Each query keeps only its own leading comment
-			[
-				"-- first\nSELECT 1;\n-- second\nSELECT 2;",
-				["-- first\nSELECT 1", "-- second\nSELECT 2"],
-			],
-			// A comment between two queries attaches to the following query
-			[
-				"SELECT 1; -- between\nSELECT 2;",
-				["SELECT 1", "-- between\nSELECT 2"],
-			],
-			// # hash comments are preserved too
+			// # hash comments are preserved as a prefix
 			[
 				"# hash note\nSELECT 1;",
 				["# hash note\nSELECT 1"],
 			],
-			// /* */ block comments are preserved too
-			[
-				"/* block */ SELECT 1;",
-				["/* block */ SELECT 1"],
-			],
-			// Mixed comment types are preserved with their original formatting
+			// All three comment styles mixed, with original formatting preserved
 			[
 				"-- a\n# b\n/* c */\nSELECT 1;",
 				["-- a\n# b\n/* c */\nSELECT 1"],
 			],
-			// Pure leading whitespace / blank lines before the comment are stripped
+			// A hash comment between two queries attaches to the following query
 			[
-				"\n\n-- spaced\n\nSELECT 1;",
-				["-- spaced\n\nSELECT 1"],
+				"SELECT 1; # between\nSELECT 2;",
+				["SELECT 1", "# between\nSELECT 2"],
 			],
-			// Comment-only input yields nothing (no query to attach to)
-			["-- only a comment", []],
-			["-- line 1\n-- line 2\n", []],
-			["/* only a block */", []],
-			// A trailing comment after the last query (no following query) is dropped
-			[
-				"SELECT 1;\n-- trailing",
-				["SELECT 1"],
-			],
-			// Pure whitespace produces no leading prefix
-			[
-				"\n\nSELECT 1;\n\n",
-				["SELECT 1"],
-			],
+			// Hash-comment-only input yields nothing
+			["# only a comment", []],
 		];
 	}
 

--- a/tests/cases/MySqlMultiQueryParserTest.phpt
+++ b/tests/cases/MySqlMultiQueryParserTest.phpt
@@ -46,6 +46,114 @@ class MySqlMultiQueryParserTest extends MultiQueryParserTestCase
 
 
 	/**
+	 * @dataProvider providePreserveLeadingCommentsData
+	 * @param list<string> $expectedQueries
+	 */
+	public function testPreserveLeadingComments(string $content, array $expectedQueries): void
+	{
+		$parser = new MySqlMultiQueryParser(preserveLeadingComments: true);
+		$queries = iterator_to_array($parser->parseString($content));
+		Assert::same($expectedQueries, $queries);
+	}
+
+
+	/**
+	 * The restructured leading-comment pattern must keep streaming chunk-safe.
+	 * Every two-chunk split of the input must reproduce the whole-string result.
+	 */
+	public function testPreserveLeadingCommentsChunkBoundary(): void
+	{
+		$parser = new MySqlMultiQueryParser(preserveLeadingComments: true);
+		$content = implode("\n", [
+			'-- header comment',
+			'-- second line',
+			'SELECT 1;',
+			'',
+			'# hash note',
+			'SELECT 2;',
+			'/* block ; with semi */',
+			'SELECT 3;',
+			'SELECT 4; -- trailing',
+			'-- leading before 5',
+			'SELECT 5;',
+		]);
+
+		$expected = iterator_to_array($parser->parseString($content));
+		$len = strlen($content);
+
+		for ($i = 0; $i <= $len; $i++) {
+			$chunks = [substr($content, 0, $i), substr($content, $i)];
+			$queries = iterator_to_array($parser->parseStringStream(new \ArrayIterator($chunks)));
+			Assert::same($expected, $queries, "Failed with chunk boundary at offset $i");
+		}
+	}
+
+
+	/**
+	 * @return list<array{string, list<string>}>
+	 */
+	protected function providePreserveLeadingCommentsData(): array
+	{
+		return [
+			// Single -- comment kept as a prefix of the following query
+			[
+				"-- add users table\nCREATE TABLE users (id INT);",
+				["-- add users table\nCREATE TABLE users (id INT)"],
+			],
+			// Multiple consecutive -- comment lines
+			[
+				"-- line 1\n-- line 2\nSELECT 1;",
+				["-- line 1\n-- line 2\nSELECT 1"],
+			],
+			// Each query keeps only its own leading comment
+			[
+				"-- first\nSELECT 1;\n-- second\nSELECT 2;",
+				["-- first\nSELECT 1", "-- second\nSELECT 2"],
+			],
+			// A comment between two queries attaches to the following query
+			[
+				"SELECT 1; -- between\nSELECT 2;",
+				["SELECT 1", "-- between\nSELECT 2"],
+			],
+			// # hash comments are preserved too
+			[
+				"# hash note\nSELECT 1;",
+				["# hash note\nSELECT 1"],
+			],
+			// /* */ block comments are preserved too
+			[
+				"/* block */ SELECT 1;",
+				["/* block */ SELECT 1"],
+			],
+			// Mixed comment types are preserved with their original formatting
+			[
+				"-- a\n# b\n/* c */\nSELECT 1;",
+				["-- a\n# b\n/* c */\nSELECT 1"],
+			],
+			// Pure leading whitespace / blank lines before the comment are stripped
+			[
+				"\n\n-- spaced\n\nSELECT 1;",
+				["-- spaced\n\nSELECT 1"],
+			],
+			// Comment-only input yields nothing (no query to attach to)
+			["-- only a comment", []],
+			["-- line 1\n-- line 2\n", []],
+			["/* only a block */", []],
+			// A trailing comment after the last query (no following query) is dropped
+			[
+				"SELECT 1;\n-- trailing",
+				["SELECT 1"],
+			],
+			// Pure whitespace produces no leading prefix
+			[
+				"\n\nSELECT 1;\n\n",
+				["SELECT 1"],
+			],
+		];
+	}
+
+
+	/**
 	 * @return list<array{string, list<string>}>
 	 */
 	protected function provideSuperfluousSemicolonsData(): array

--- a/tests/cases/MySqlMultiQueryParserTest.phpt
+++ b/tests/cases/MySqlMultiQueryParserTest.phpt
@@ -8,7 +8,7 @@ namespace Nextras\MultiQueryParser;
 
 use Nextras\MultiQueryParser\Fragment\Comment;
 use Nextras\MultiQueryParser\Fragment\Query;
-use Nextras\MultiQueryParser\Strategy\KeepLeadingComments;
+use Nextras\MultiQueryParser\Strategy\PrependLeadingComments;
 use Tester\Assert;
 
 
@@ -57,7 +57,7 @@ class MySqlMultiQueryParserTest extends MultiQueryParserTestCase
 	 */
 	public function testPreserveLeadingCommentsHash(string $content, array $expectedQueries): void
 	{
-		$parser = $this->createParser(new KeepLeadingComments());
+		$parser = $this->createParser(new PrependLeadingComments());
 		$queries = iterator_to_array($parser->parseString($content));
 		Assert::same($expectedQueries, $queries);
 	}
@@ -111,8 +111,8 @@ class MySqlMultiQueryParserTest extends MultiQueryParserTestCase
 		assert($query instanceof Query);
 		Assert::same('SELECT 1', $query->sql);
 
-		// under KeepLeadingComments the comment attaches to the following query
-		$queries = iterator_to_array($this->createParser(new KeepLeadingComments())->parseString($content));
+		// under PrependLeadingComments the comment attaches to the following query
+		$queries = iterator_to_array($this->createParser(new PrependLeadingComments())->parseString($content));
 		Assert::same(["-- before delimiter\nSELECT 1"], $queries);
 	}
 

--- a/tests/cases/PostgreSqlMultiQueryParserTest.phpt
+++ b/tests/cases/PostgreSqlMultiQueryParserTest.phpt
@@ -15,9 +15,9 @@ require_once __DIR__ . '/../inc/MultiQueryParserTestCase.php';
 
 class PostgreSqlMultiQueryParserTest extends MultiQueryParserTestCase
 {
-	protected function createParser(): IMultiQueryParser
+	protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser
 	{
-		return new PostgreSqlMultiQueryParser();
+		return new PostgreSqlMultiQueryParser($preserveLeadingComments);
 	}
 
 

--- a/tests/cases/PostgreSqlMultiQueryParserTest.phpt
+++ b/tests/cases/PostgreSqlMultiQueryParserTest.phpt
@@ -15,9 +15,9 @@ require_once __DIR__ . '/../inc/MultiQueryParserTestCase.php';
 
 class PostgreSqlMultiQueryParserTest extends MultiQueryParserTestCase
 {
-	protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser
+	protected function createParser(?CommentStrategy $commentStrategy = null): IMultiQueryParser
 	{
-		return new PostgreSqlMultiQueryParser($preserveLeadingComments);
+		return new PostgreSqlMultiQueryParser($commentStrategy);
 	}
 
 

--- a/tests/cases/SqlServerMultiQueryParserTest.phpt
+++ b/tests/cases/SqlServerMultiQueryParserTest.phpt
@@ -15,9 +15,9 @@ require_once __DIR__ . '/../inc/MultiQueryParserTestCase.php';
 
 class SqlServerMultiQueryParserTest extends MultiQueryParserTestCase
 {
-	protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser
+	protected function createParser(?CommentStrategy $commentStrategy = null): IMultiQueryParser
 	{
-		return new SqlServerMultiQueryParser($preserveLeadingComments);
+		return new SqlServerMultiQueryParser($commentStrategy);
 	}
 
 

--- a/tests/cases/SqlServerMultiQueryParserTest.phpt
+++ b/tests/cases/SqlServerMultiQueryParserTest.phpt
@@ -15,9 +15,9 @@ require_once __DIR__ . '/../inc/MultiQueryParserTestCase.php';
 
 class SqlServerMultiQueryParserTest extends MultiQueryParserTestCase
 {
-	protected function createParser(): IMultiQueryParser
+	protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser
 	{
-		return new SqlServerMultiQueryParser();
+		return new SqlServerMultiQueryParser($preserveLeadingComments);
 	}
 
 

--- a/tests/cases/SqliteMultiQueryParserTest.phpt
+++ b/tests/cases/SqliteMultiQueryParserTest.phpt
@@ -15,9 +15,9 @@ require_once __DIR__ . '/../inc/MultiQueryParserTestCase.php';
 
 class SqliteMultiQueryParserTest extends MultiQueryParserTestCase
 {
-	protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser
+	protected function createParser(?CommentStrategy $commentStrategy = null): IMultiQueryParser
 	{
-		return new SqliteMultiQueryParser($preserveLeadingComments);
+		return new SqliteMultiQueryParser($commentStrategy);
 	}
 
 

--- a/tests/cases/SqliteMultiQueryParserTest.phpt
+++ b/tests/cases/SqliteMultiQueryParserTest.phpt
@@ -15,9 +15,9 @@ require_once __DIR__ . '/../inc/MultiQueryParserTestCase.php';
 
 class SqliteMultiQueryParserTest extends MultiQueryParserTestCase
 {
-	protected function createParser(): IMultiQueryParser
+	protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser
 	{
-		return new SqliteMultiQueryParser();
+		return new SqliteMultiQueryParser($preserveLeadingComments);
 	}
 
 

--- a/tests/inc/MultiQueryParserTestCase.php
+++ b/tests/inc/MultiQueryParserTestCase.php
@@ -2,15 +2,20 @@
 
 namespace Nextras\MultiQueryParser;
 
+use Iterator;
 use LogicException;
 use Nextras\MultiQueryParser\Exception\RuntimeException;
+use Nextras\MultiQueryParser\Fragment\Comment;
+use Nextras\MultiQueryParser\Fragment\Fragment;
+use Nextras\MultiQueryParser\Fragment\Query;
+use Nextras\MultiQueryParser\Strategy\KeepLeadingComments;
 use Tester\Assert;
 use Tester\TestCase;
 
 
 abstract class MultiQueryParserTestCase extends TestCase
 {
-	abstract protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser;
+	abstract protected function createParser(?CommentStrategy $commentStrategy = null): IMultiQueryParser;
 
 
 	/**
@@ -89,7 +94,7 @@ abstract class MultiQueryParserTestCase extends TestCase
 	 */
 	public function testPreserveLeadingComments(string $content, array $expectedQueries): void
 	{
-		$parser = $this->createParser(preserveLeadingComments: true);
+		$parser = $this->createParser(new KeepLeadingComments());
 		$queries = iterator_to_array($parser->parseString($content));
 		Assert::same($expectedQueries, $queries);
 	}
@@ -101,7 +106,7 @@ abstract class MultiQueryParserTestCase extends TestCase
 	 */
 	public function testPreserveLeadingCommentsChunkBoundary(): void
 	{
-		$parser = $this->createParser(preserveLeadingComments: true);
+		$parser = $this->createParser(new KeepLeadingComments());
 		$content = implode("\n", [
 			'-- header comment',
 			'-- second line',
@@ -123,6 +128,58 @@ abstract class MultiQueryParserTestCase extends TestCase
 			$queries = iterator_to_array($parser->parseStringStream(new \ArrayIterator($chunks)));
 			Assert::same($expected, $queries, "Failed with chunk boundary at offset $i");
 		}
+	}
+
+
+	/**
+	 * A comment trailing the last query (with no query following it) must still be emitted as a
+	 * Comment fragment by the parser, so that a custom CommentStrategy can act on it. The bundled
+	 * strategies happen to drop it, which is why this has to be asserted at the fragment level
+	 * rather than via the yielded query strings.
+	 */
+	public function testTrailingCommentIsEmittedAsFragment(): void
+	{
+		$fragments = $this->collectFragments("SELECT 1;\n-- trailing");
+		Assert::count(2, $fragments);
+
+		$query = $fragments[0];
+		Assert::type(Query::class, $query);
+		assert($query instanceof Query);
+		Assert::same('SELECT 1', $query->sql);
+
+		$comment = $fragments[1];
+		Assert::type(Comment::class, $comment);
+		assert($comment instanceof Comment);
+		Assert::same('-- trailing', $comment->text);
+	}
+
+
+	/**
+	 * Parses the content and returns the raw Fragment stream the parser emits (before any
+	 * CommentStrategy collapses it), by plugging in a fragment-collecting strategy.
+	 *
+	 * @return list<Fragment>
+	 */
+	protected function collectFragments(string $content): array
+	{
+		$strategy = new class implements CommentStrategy {
+			/** @var list<Fragment> */
+			public array $fragments = [];
+
+
+			public function apply(Iterator $fragments): Iterator
+			{
+				foreach ($fragments as $fragment) {
+					$this->fragments[] = $fragment;
+				}
+
+				yield from [];
+			}
+		};
+
+		iterator_to_array($this->createParser($strategy)->parseString($content));
+
+		return $strategy->fragments;
 	}
 
 

--- a/tests/inc/MultiQueryParserTestCase.php
+++ b/tests/inc/MultiQueryParserTestCase.php
@@ -8,7 +8,7 @@ use Nextras\MultiQueryParser\Exception\RuntimeException;
 use Nextras\MultiQueryParser\Fragment\Comment;
 use Nextras\MultiQueryParser\Fragment\Fragment;
 use Nextras\MultiQueryParser\Fragment\Query;
-use Nextras\MultiQueryParser\Strategy\KeepLeadingComments;
+use Nextras\MultiQueryParser\Strategy\PrependLeadingComments;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -94,7 +94,7 @@ abstract class MultiQueryParserTestCase extends TestCase
 	 */
 	public function testPreserveLeadingComments(string $content, array $expectedQueries): void
 	{
-		$parser = $this->createParser(new KeepLeadingComments());
+		$parser = $this->createParser(new PrependLeadingComments());
 		$queries = iterator_to_array($parser->parseString($content));
 		Assert::same($expectedQueries, $queries);
 	}
@@ -106,7 +106,7 @@ abstract class MultiQueryParserTestCase extends TestCase
 	 */
 	public function testPreserveLeadingCommentsChunkBoundary(): void
 	{
-		$parser = $this->createParser(new KeepLeadingComments());
+		$parser = $this->createParser(new PrependLeadingComments());
 		$content = implode("\n", [
 			'-- header comment',
 			'-- second line',

--- a/tests/inc/MultiQueryParserTestCase.php
+++ b/tests/inc/MultiQueryParserTestCase.php
@@ -10,7 +10,7 @@ use Tester\TestCase;
 
 abstract class MultiQueryParserTestCase extends TestCase
 {
-	abstract protected function createParser(): IMultiQueryParser;
+	abstract protected function createParser(bool $preserveLeadingComments = false): IMultiQueryParser;
 
 
 	/**
@@ -77,6 +77,111 @@ abstract class MultiQueryParserTestCase extends TestCase
 		$parser = $this->createParser();
 		$queries = iterator_to_array($parser->parseStringStream(new \ArrayIterator($chunks)));
 		Assert::same($expectedQueries, $queries);
+	}
+
+
+	/**
+	 * Dialect-agnostic leading-comment cases (line and block comments), shared by every
+	 * parser. Dialect-specific comment styles are tested in the subclasses.
+	 *
+	 * @dataProvider provideCommonPreserveLeadingCommentsData
+	 * @param list<string> $expectedQueries
+	 */
+	public function testPreserveLeadingComments(string $content, array $expectedQueries): void
+	{
+		$parser = $this->createParser(preserveLeadingComments: true);
+		$queries = iterator_to_array($parser->parseString($content));
+		Assert::same($expectedQueries, $queries);
+	}
+
+
+	/**
+	 * The restructured leading-comment pattern must keep streaming chunk-safe:
+	 * every two-chunk split of the input must reproduce the whole-string result.
+	 */
+	public function testPreserveLeadingCommentsChunkBoundary(): void
+	{
+		$parser = $this->createParser(preserveLeadingComments: true);
+		$content = implode("\n", [
+			'-- header comment',
+			'-- second line',
+			'SELECT 1;',
+			'',
+			'SELECT 2;',
+			'/* block ; with semi */',
+			'SELECT 3;',
+			'SELECT 4; -- trailing',
+			'-- leading before 5',
+			'SELECT 5;',
+		]);
+
+		$expected = iterator_to_array($parser->parseString($content));
+		$len = strlen($content);
+
+		for ($i = 0; $i <= $len; $i++) {
+			$chunks = [substr($content, 0, $i), substr($content, $i)];
+			$queries = iterator_to_array($parser->parseStringStream(new \ArrayIterator($chunks)));
+			Assert::same($expected, $queries, "Failed with chunk boundary at offset $i");
+		}
+	}
+
+
+	/**
+	 * @return list<array{string, list<string>}>
+	 */
+	protected function provideCommonPreserveLeadingCommentsData(): array
+	{
+		return [
+			// A single -- comment kept as a prefix of the following query
+			[
+				"-- create the users table\nCREATE TABLE users (id INT);",
+				["-- create the users table\nCREATE TABLE users (id INT)"],
+			],
+			// Multiple consecutive -- comment lines
+			[
+				"-- line 1\n-- line 2\nSELECT 1;",
+				["-- line 1\n-- line 2\nSELECT 1"],
+			],
+			// Each query keeps only its own leading comment
+			[
+				"-- first\nSELECT 1;\n-- second\nSELECT 2;",
+				["-- first\nSELECT 1", "-- second\nSELECT 2"],
+			],
+			// A comment between two queries attaches to the following query
+			[
+				"SELECT 1; -- between\nSELECT 2;",
+				["SELECT 1", "-- between\nSELECT 2"],
+			],
+			// /* */ block comments are preserved too
+			[
+				"/* block */ SELECT 1;",
+				["/* block */ SELECT 1"],
+			],
+			// Mixed comment types preserve their original formatting
+			[
+				"-- a\n/* b */\nSELECT 1;",
+				["-- a\n/* b */\nSELECT 1"],
+			],
+			// Pure leading whitespace / blank lines before the comment are stripped
+			[
+				"\n\n-- spaced\n\nSELECT 1;",
+				["-- spaced\n\nSELECT 1"],
+			],
+			// Comment-only input yields nothing (no query to attach to)
+			["-- only a comment", []],
+			["-- line 1\n-- line 2\n", []],
+			["/* only a block */", []],
+			// A trailing comment after the last query (no following query) is dropped
+			[
+				"SELECT 1;\n-- trailing",
+				["SELECT 1"],
+			],
+			// Pure whitespace produces no leading prefix
+			[
+				"\n\nSELECT 1;\n\n",
+				["SELECT 1"],
+			],
+		];
 	}
 
 


### PR DESCRIPTION
## Summary

Adds the ability to retain SQL comments that precede a query, via a pluggable `CommentStrategy` injected into the parser constructor. By default comments are still stripped, so existing behavior — and the public `Iterator<string>` return type — are unchanged.

> This supersedes the original `preserveLeadingComments: bool` flag (see discussion below): rather than bake an opinionated comment-handling policy into the parser, the policy is now a swappable strategy and the parser core stays neutral.

## Motivation

The SQL that runs is visible in observability tools, and it's a common pattern to prepend a comment to a query so it shows up there. **Prepending** (not appending) matters because the full query is often truncated in those tools:

```sql
-- why this risky alter is safe to run
ALTER something_complicated;
```

Previously the parser unconditionally stripped such comments.

## Design

The parser now tokenizes input into a neutral stream of `Query` and `Comment` fragments; a `CommentStrategy` collapses that stream into the final query strings:

```php
interface CommentStrategy
{
    /**
     * @param  Iterator<Fragment> $fragments
     * @return Iterator<string>
     */
    public function apply(Iterator $fragments): Iterator;
}
```

Two strategies are bundled:

- **`DropComments`** (default) — drops every comment; reproduces the historical output byte-for-byte.
- **`PrependLeadingComments`** — prepends the comments preceding a query as a prefix of that query.

```php
$parser = new MySqlMultiQueryParser(new PrependLeadingComments());

foreach ($parser->parseString("-- create the users table\nCREATE TABLE users (id INT);") as $query) {
    echo $query; // "-- create the users table\nCREATE TABLE users (id INT)"
}
```

A user wanting a different policy (blank-line separators, trailing-comment handling, …) implements `CommentStrategy` themselves; the non-standardized "a comment belongs to the following query" assumption lives only in `PrependLeadingComments`, not in the parser.

## Behavior (`PrependLeadingComments`)

- All comment styles of the dialect (`--`, `/* */`, and `#` for MySQL) directly preceding a query are preserved with their original formatting; only pure leading whitespace is stripped.
- A comment between two queries attaches to the following one.
- A comment with no following query (a trailing comment at end of input, or one preceding a MySQL `DELIMITER` directive) is faithfully emitted as a `Comment` fragment, but dropped by both bundled strategies since there is no query to attach it to.

## BC

- Public return type stays `Iterator<string>`; `IMultiQueryParser` is unchanged.
- Default `DropComments` ⇒ no behavior change.
- Still targets PHP 8.0 (no `readonly` / `new` in default args).

## Tests

- Dialect-agnostic comment cases run across all four parsers; MySQL keeps its `#`- and `DELIMITER`-specific cases.
- Fragment-level tests assert the parser faithfully emits `Comment` fragments even when no query follows (trailing comment, comment-before-`DELIMITER`).
- Streaming chunk-boundary safety verified exhaustively; phpstan level 8 + strict-rules clean.

Co-Authored-By: Claude Code
